### PR TITLE
Update fibref.ml

### DIFF
--- a/homework7/examples/fibref.ml
+++ b/homework7/examples/fibref.ml
@@ -1,11 +1,11 @@
-let prev : ref int = ref 0 in
-let curr : ref int = ref 1 in
+let curr : ref int = ref 0 in
+let next : ref int = ref 1 in
 let rec fib (n : int) : () =
   if n == 0 then ()
   else 
-    let temp : int = !curr in 
-    let x : () = curr := !prev + !curr in
-    let y : () = prev := temp in
+    let temp : int = !next in 
+    let x : () = next := !curr + !next in
+    let y : () = curr := temp in
     fib (n - 1)
 in
 let t : () = fib 8 in 


### PR DESCRIPTION
The previous implementation returned the (n+1)th fibonacci number.  It returned the value of !curr, and  at the beginning prev references the 0th fibonnaci number and curr references the 1st fibonacci number. Each application of fib n progresses the pair by 1. Therefore, fib 0 would return the 1st fibonacci number, fib 1 the 2nd, etc. Another solution would be to return !prev, but that is less pretty.