### PR TITLE
Fix .gitignore

### DIFF
--- a/homework10/.gitignore
+++ b/homework10/.gitignore
@@ -1,3 +1,1 @@
-let rec app f = fun x -> f x in
-let rec add2 x = x + 2 in
-print_int (app add2 40)
+/target


### PR DESCRIPTION
`.gitignore` in homework10 seems to contain irrelevant MiniML code.  Fix it, and include `/target` directory, which is the standard directory to ignore in Rust projects.